### PR TITLE
 bundle gem and adobe-reader install &  add path berks & readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,18 @@ This is repo for collecting cookbooks for Dev workstation environments.
 
 ## Usage
 
+###download repository
+```
+% git clone https://github.com/uzyexe/chef-dev.git
+
+```
+
 ### Mac OS X
 
 ```
-% rake init
-% rake
+% cd chef-dev  
+% sudo rake init
+% sudo rake
 ```
 
 ### Linux

--- a/Rakefile
+++ b/Rakefile
@@ -5,17 +5,19 @@ task :init => [:bundle, :berks]
 
 desc "Install rubygems"
 task :bundle do
+  sh "gem install bundler"
   sh "bundle --path vendor/bundle --binstubs .bundle/bin"
 end
 
 desc "Install third-paty Chef cookbooks"
 task :berks do
-  sh "berks vendor cookbooks"
+  sh ".bundle/bin/berks vendor cookbooks"
 end
 
 namespace :run do
   desc "Run at OSX environment"
   task :osx do
+    sh "brew cask install adobe-reader"
     sh "chef-solo -c config/solo.rb -j nodes/osx.json"
   end
 


### PR DESCRIPTION
### 以下問題の解決
- bundleがインストールされていない。
- berksのパスが通らない
- adobe readerのインストール時にパスを求められこける
- Readme.mdのコマンドの不足
