### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This is repo for collecting cookbooks for Dev workstation environments.
 ### Mac OS X
 
 ```
-% cd chef-dev  
+% brew install caskroom/cask/brew-cask
+% cd chef-dev
 % sudo rake init
 % sudo rake
 ```


### PR DESCRIPTION
Mac OS X にてコマンドの依存関係があり、事前にhomebrew-cask をインストールする必要があるためREADME.mdを修正。

詳細として、

```
sudo rake
```

その後、エラーメッセージが出力

```
brew cask install --force adobe-reader
Error: Unknown command: cask
rake aborted!
```

原因としては、homebrew-cask が存在しないので、インストールの必要がある。
