### PR TITLE
Fix Chef Deployment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,8 @@ end
 namespace :run do
   desc "Run at OSX environment"
   task :osx do
-    sh "brew cask install --force adobe-reader"
     sh "chef-solo -c config/solo.rb -j nodes/osx.json"
+    sh "brew cask install --force adobe-reader"
   end
 
   desc "Run at Linux environment"

--- a/nodes/osx.json
+++ b/nodes/osx.json
@@ -40,7 +40,6 @@
       "zsh"
     ],
     "casks": [
-      "adobe-reader",
       "alfred",
       "atom",
       "gitbook",


### PR DESCRIPTION
Chef Deployment の実行順番を修正しました。
原因として、Rakefileにて、osx.json を実行する前に、 brew cask install --force adobe-reader を置いていたこと。
